### PR TITLE
Adds macro and DRO functions to I2C keypad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Keypad plugin
 
+**Modified for Interactive two-way control**
+
 This plugin can be used for jogging, controlling feedhold, cycle start etc. via single character commands.
 The command characters can be delivered either via an I2C or an UART port.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **Modified for Interactive two-way control**
 
+This version of the I2C keypad plugin is modified to send status info for display on the I2C jogger.  It also implements some basic macro functionality in response to button presses.
+
+https://github.com/Expatria-Technologies/I2C_Jog_Controller
+
 This plugin can be used for jogging, controlling feedhold, cycle start etc. via single character commands.
 The command characters can be delivered either via an I2C or an UART port.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Character to action map:
 | `0x8A`   | Toggle Fan 0 output<sup>1</sup> |
 | `0x8B`   | Enable MPG full control<sup>2</sup> |
 | `0x85`   | Cancel jog motion<sup>3</sup> |
+| `0x90`   | Feed Override Reset         |
+| `0x91`   | Feed Override Coarse Up     |
+| `0x92`   | Feed Override Coarse Down   |
+| `0x99`   | Spindle Override Reset      |
+| `0x9A`   | Spindle Override Coarse Up  |
+| `0x9B`   | Spindle Override Coarse Down|
+| `0x9E`   | Spindle Toggle (Hold Only)  |
 | `0`      | Enable step mode jogging    |
 | `1`      | Enable slow jogging mode    |
 | `2`      | Enable fast jogging mode    |

--- a/keypad.c
+++ b/keypad.c
@@ -169,6 +169,29 @@ static void keypad_process_keypress (sys_state_t state)
 
         switch(keycode) {
 
+            case 0x91:                                   // Feed Override Coarse Up
+                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_PLUS);
+                break;            
+            case 0x92:                                   // Feed Override Coarse Down
+                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_MINUS);
+                break;   
+            case 0x90:                                   // Feed Override Reset
+                enqueue_feed_override(CMD_OVERRIDE_FEED_RESET);
+                break;                
+
+            case 0x9A:                                   // Spindle Override Coarse Up
+                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_PLUS);
+                break;            
+            case 0x9B:                                   // Spindle Override Coarse Down
+                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_MINUS);
+                break;   
+            case 0x99:                                   // Spindle Override Reset
+                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_RESET);
+                break;
+            case 0x9E:                                   // Spindle on/off Toggle
+                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_STOP);
+                break;                                   
+
             case 'M':                                   // Mist override
                 enqueue_accessory_override(CMD_OVERRIDE_COOLANT_MIST_TOGGLE);
                 break;
@@ -301,7 +324,7 @@ static void onReportOptions (bool newopt)
     on_report_options(newopt);
 
     if(!newopt)
-        hal.stream.write("[PLUGIN:KEYPAD v1.32]"  ASCII_EOL);
+        hal.stream.write("[PLUGIN:KEYPAD v1.33]"  ASCII_EOL);
 }
 
 ISR_CODE bool keypad_enqueue_keycode (char c)

--- a/keypad.c
+++ b/keypad.c
@@ -55,9 +55,9 @@ typedef struct {
 } keybuffer_t;
 
 static on_state_change_ptr on_state_change;
-static on_execute_realtime_ptr on_execute_realtime; // For real time loop insertion
+//static on_execute_realtime_ptr on_execute_realtime; // For real time loop insertion
 
-#define SEND_STATUS_DELAY 250
+#define SEND_STATUS_DELAY 25
 
 typedef struct Machine_status_packet {
 uint8_t address;
@@ -71,11 +71,11 @@ coolant_state_t coolant_state;
 uint8_t jog_mode;
 } Machine_status_packet;
 
-static void status_loop_function (void);
+//static void status_loop_function (void);
 
 Machine_status_packet status_packet;
 
-char *status_ptr = (char*) &status_packet;
+uint8_t *status_ptr = (uint8_t*) &status_packet;
 
 static bool jogging = false, keyreleased = true;
 static jogmode_t jogMode = JogMode_Fast;
@@ -239,32 +239,8 @@ static void keypad_process_keypress (sys_state_t state)
 
             case '?':                                    // Request status report.  Currently NOT the real-time status as we only want to send if a pendant is present and ready to receive.
                 hal.delay_ms(1, send_status_info);
-                break;  
-
-            case 0x91:                                   // Feed Override Coarse Up
-                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_PLUS);
-                break;            
-            case 0x92:                                   // Feed Override Coarse Down
-                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_MINUS);
-                break;   
-            case 0x90:                                   // Feed Override Reset
-                enqueue_feed_override(CMD_OVERRIDE_FEED_RESET);
-                break;                
-
-            case 0x9A:                                   // Spindle Override Coarse Up
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_PLUS);
-                break;            
-            case 0x9B:                                   // Spindle Override Coarse Down
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_MINUS);
-                break;   
-            case 0x99:                                   // Spindle Override Reset
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_RESET);
-                break;
-            case 0x9E:                                   // Spindle on/off Toggle
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_STOP);
-                break;                                   
-
-            case 'M':                                   // Mist override
+                break;                                       
+             case 'M':                                   // Mist override
                 enqueue_accessory_override(CMD_OVERRIDE_COOLANT_MIST_TOGGLE);
                 break;
 
@@ -299,32 +275,6 @@ static void keypad_process_keypress (sys_state_t state)
 
             case 'H':                                   // Home axes
                 strcpy(command, "$H");
-                break;
-
-         // Feed rate and spindle overrides
-
-             case 'I':                                   // Feed rate coarse override -10%
-                enqueue_feed_override(CMD_OVERRIDE_FEED_RESET);
-                break;
-
-            case 'i':                                   // Feed rate coarse override +10%
-                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_PLUS);
-                break;
-
-            case 'j':                                   // Feed rate fine override +1%
-                enqueue_feed_override(CMD_OVERRIDE_FEED_COARSE_MINUS);
-                break;
-
-            case 'K':                                  // Spindle RPM coarse override -10%
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_RESET);
-                break;
-
-            case 'k':                                   // Spindle RPM coarse override +10%
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_PLUS);
-                break;
-
-            case 'z':                                   // Spindle RPM fine override +1%
-                enqueue_accessory_override(CMD_OVERRIDE_SPINDLE_COARSE_MINUS);
                 break;
 
          // Pass most of the top bit set commands trough unmodified
@@ -523,7 +473,7 @@ static void onStateChanged (sys_state_t state)
     send_status_info();
 }
 
-static void onRealtimeReport (sys_state_t state)
+static void onRealtimeReport (stream_write_ptr stream_write, report_tracking_flags_t report)
 {
     hal.delay_ms(SEND_STATUS_DELAY,send_status_info);
     //send_status_info();

--- a/keypad.c
+++ b/keypad.c
@@ -213,7 +213,7 @@ static void send_status_info (void)
     status_packet.spindle_override = sys.override.spindle_rpm;
     status_packet.spindle_stop = sys.override.spindle_stop.value;
     status_packet.alarm = (uint8_t) sys.alarm;
-    status_packet.home_state = (uint8_t)((sys.homing.mask & sys.homed.mask) == sys.homed.mask ? 1 : 0);
+    status_packet.home_state = (uint8_t)(sys.homing.mask & sys.homed.mask);
 
     I2C_Send (KEYPAD_I2CADDR, status_ptr, sizeof(Machine_status_packet), 0);
 }
@@ -443,6 +443,9 @@ ISR_CODE bool keypad_strobe_handler (uint_fast8_t id, bool keydown)
     else if(jogging) {
         jogging = false;
         grbl.enqueue_realtime_command(CMD_JOG_CANCEL);
+        keybuf.tail = keybuf.head; // flush keycode buffer
+    }
+    else {
         keybuf.tail = keybuf.head; // flush keycode buffer
     }
 

--- a/keypad.c
+++ b/keypad.c
@@ -259,13 +259,15 @@ static void macro_settings_save (void)
 static void macro_settings_restore (void)
 {   
     uint_fast8_t idx;
+    uint_fast8_t idy;
     char default_str[] = "G4P0";
 
     // Register empty macro strings.
     for(idx = 0; idx < N_MACROS; idx++) {
-            for(idx = 0; idx < strlen(default_str); idx++) {
-                macro_plugin_settings.macro[4].data[idx] = default_str[idx];
+            for(idy = 0; idy < strlen(default_str); idy++) {
+                macro_plugin_settings.macro[idx].data[idy] = default_str[idy];
             };
+            macro_plugin_settings.macro[idx].data[idy] = '\0';
     };
 
     char cmd_str[] = "S200M03";

--- a/keypad.c
+++ b/keypad.c
@@ -68,7 +68,7 @@ uint8_t feed_override;
 uint8_t spindle_override;
 uint8_t spindle_stop;
 coolant_state_t coolant_state;
-
+uint8_t jog_mode;
 } Machine_status_packet;
 
 static void status_loop_function (void);
@@ -183,9 +183,12 @@ static void send_status_info (void)
     status_packet.address = 0x01;
     
     switch (state_get()){
-        case STATE_ALARM || STATE_ESTOP:
+        case STATE_ALARM:
             status_packet.machine_state = 1;
             break;
+        case STATE_ESTOP:
+            status_packet.machine_state = 1;
+            break;            
         case STATE_CYCLE:
             status_packet.machine_state = 2;
             break;
@@ -214,6 +217,7 @@ static void send_status_info (void)
     status_packet.spindle_stop = sys.override.spindle_stop.value;
     status_packet.alarm = (uint8_t) sys.alarm;
     status_packet.home_state = (uint8_t)(sys.homing.mask & sys.homed.mask);
+    status_packet.jog_mode = (uint8_t) jogMode;
 
     I2C_Send (KEYPAD_I2CADDR, status_ptr, sizeof(Machine_status_packet), 0);
 }
@@ -454,7 +458,7 @@ ISR_CODE bool keypad_strobe_handler (uint_fast8_t id, bool keydown)
 
 static void onStateChanged (sys_state_t state)
 {
-    //hal.delay_ms(SEND_STATUS_DELAY,NULL);
+    hal.delay_ms(50,NULL);
     send_status_info();
 }
 

--- a/keypad.c
+++ b/keypad.c
@@ -259,12 +259,16 @@ static void macro_settings_save (void)
 static void macro_settings_restore (void)
 {   
     uint_fast8_t idx;
-    char cmd_str[] = "S200M03";
+    char default_str[] = "G4P0";
 
     // Register empty macro strings.
     for(idx = 0; idx < N_MACROS; idx++) {
-        *macro_plugin_settings.macro[idx].data = '\0';
+            for(idx = 0; idx < strlen(default_str); idx++) {
+                macro_plugin_settings.macro[4].data[idx] = default_str[idx];
+            };
     };
+
+    char cmd_str[] = "S200M03";
 
     for(idx = 0; idx < strlen(cmd_str); idx++) {
         macro_plugin_settings.macro[4].data[idx] = cmd_str[idx];
@@ -517,11 +521,11 @@ static void keypad_process_keypress (sys_state_t state)
                 break;
              case MACROLEFT:                                   //Macro 2 right
                 //strcat(strcpy(command, "G10 L20 P0 X"), ftoa(-1.27, 5));
-                execute_macro(1); 
+                execute_macro(3); 
                 break;
              case MACRORIGHT:                                   //Macro 4 left
                 //strcat(strcpy(command, "G10 L20 P0 X"), ftoa(1.27, 5));
-                execute_macro(3);             
+                execute_macro(1);             
                 break;
              case SPINON:                                   //Macro 5 is special
                 spindle_state = hal.spindle.get_state();

--- a/keypad.c
+++ b/keypad.c
@@ -47,7 +47,7 @@
 #include "grbl/protocol.h"
 #include "grbl/nvs_buffer.h"
 #include "grbl/state_machine.h"
-#include "grbl/limits.h"
+#include "grbl/machine_limits.h"
 #endif
 
 typedef struct {

--- a/keypad.h
+++ b/keypad.h
@@ -111,7 +111,7 @@ typedef struct {
 
 typedef struct {
     uint8_t port;
-    char data[128];
+    char data[127];
 } macro_setting_t;
 
 typedef struct {
@@ -119,6 +119,7 @@ typedef struct {
 } macro_settings_t;
 
 extern keypad_t keypad;
+
 
 bool keypad_init (void);
 bool keypad_enqueue_keycode (char c);

--- a/keypad.h
+++ b/keypad.h
@@ -30,7 +30,7 @@
 #include "grbl/settings.h"
 #endif
 
-#define KEYBUF_SIZE 8 // must be a power of 2
+#define KEYBUF_SIZE 128 // must be a power of 2
 #define KEYPAD_I2CADDR 0x49
 #define STATUSDATA_SIZE 256
 

--- a/keypad.h
+++ b/keypad.h
@@ -30,6 +30,12 @@
 #include "grbl/settings.h"
 #endif
 
+#if N_AXIS > 3
+#define N_MACROS 5
+#else
+#define N_MACROS 7
+#endif
+
 #define KEYBUF_SIZE 8 // must be a power of 2
 #define KEYPAD_I2CADDR 0x49
 #define STATUSDATA_SIZE 256
@@ -49,17 +55,16 @@
 #define JOG_XLZU 'u'
 #define JOG_XLZD 'x'
 
-#define ZEROYU 0x18
-#define ZEROYD 0x19
-#define ZEROXL 0x1B
-#define ZEROXR 0x1A
-#define ZEROZ  0x7D
-#define OFFSET 0x7C
-#define ZEROALL  0x8E
+#define MACROUP 0x18
+#define MACRODOWN 0x19
+#define MACROLEFT 0x1B
+#define MACRORIGHT 0x1A
+#define MACROLOWER  0x7D
+#define MACRORAISE 0x7C
+#define MACROHOME  0x8E
 #define RESET  0x7F
 #define UNLOCK 0x80
 #define SPINON 0x81
-
 
 typedef enum {
     JogMode_Fast = 0,
@@ -73,6 +78,26 @@ typedef enum {
     JogModify_001
 } jogmodify_t;
 
+typedef struct Machine_status_packet {
+uint8_t address;
+uint8_t machine_state;
+uint8_t alarm;
+uint8_t home_state;
+uint8_t feed_override;
+uint8_t spindle_override;
+uint8_t spindle_stop;
+int spindle_rpm;
+float feed_rate;
+coolant_state_t coolant_state;
+uint8_t jog_mode;  //includes both modifier as well as mode
+float jog_stepsize;
+coord_system_id_t current_wcs;  //active WCS or MCS modal state
+float x_coordinate;
+float y_coordinate;
+float z_coordinate;
+float a_coordinate;
+} Machine_status_packet;
+
 typedef void (*keycode_callback_ptr)(const char c);
 typedef bool (*on_keypress_preview_ptr)(const char c, uint_fast16_t state);
 typedef void (*on_jogmode_changed_ptr)(jogmode_t jogmode);
@@ -83,6 +108,15 @@ typedef struct {
     on_jogmode_changed_ptr on_jogmode_changed;
     on_jogmodify_changed_ptr on_jogmodify_changed;
 } keypad_t;
+
+typedef struct {
+    uint8_t port;
+    char data[128];
+} macro_setting_t;
+
+typedef struct {
+    macro_setting_t macro[N_MACROS];
+} macro_settings_t;
 
 extern keypad_t keypad;
 

--- a/keypad.h
+++ b/keypad.h
@@ -32,6 +32,7 @@
 
 #define KEYBUF_SIZE 8 // must be a power of 2
 #define KEYPAD_I2CADDR 0x49
+#define STATUSDATA_SIZE 256
 
 #define JOG_XR   'R'
 #define JOG_XL   'L'

--- a/keypad.h
+++ b/keypad.h
@@ -30,7 +30,7 @@
 #include "grbl/settings.h"
 #endif
 
-#define KEYBUF_SIZE 128 // must be a power of 2
+#define KEYBUF_SIZE 8 // must be a power of 2
 #define KEYPAD_I2CADDR 0x49
 #define STATUSDATA_SIZE 256
 
@@ -49,19 +49,45 @@
 #define JOG_XLZU 'u'
 #define JOG_XLZD 'x'
 
+#define ZEROYU 0x18
+#define ZEROYD 0x19
+#define ZEROXL 0x1B
+#define ZEROXR 0x1A
+#define ZEROZ  0x7D
+#define OFFSET 0x7C
+#define ZEROALL  0x8E
+#define RESET  0x7F
+#define UNLOCK 0x80
+#define SPINON 0x81
+
+
 typedef enum {
     JogMode_Fast = 0,
     JogMode_Slow,
     JogMode_Step
 } jogmode_t;
 
+typedef enum {
+    JogModify_1 = 0,
+    JogModify_01,
+    JogModify_001
+} jogmodify_t;
+
+typedef struct {
+    float xy_diameter;
+    float z_height;
+    float probe_rpm;
+} pendant_probe_settings_t;
+
 typedef void (*keycode_callback_ptr)(const char c);
 typedef bool (*on_keypress_preview_ptr)(const char c, uint_fast16_t state);
 typedef void (*on_jogmode_changed_ptr)(jogmode_t jogmode);
+typedef void (*on_jogmodify_changed_ptr)(jogmodify_t jogmodify);
 
 typedef struct {
     on_keypress_preview_ptr on_keypress_preview;
     on_jogmode_changed_ptr on_jogmode_changed;
+    on_jogmodify_changed_ptr on_jogmodify_changed;
 } keypad_t;
 
 extern keypad_t keypad;

--- a/keypad.h
+++ b/keypad.h
@@ -73,12 +73,6 @@ typedef enum {
     JogModify_001
 } jogmodify_t;
 
-typedef struct {
-    float xy_diameter;
-    float z_height;
-    float probe_rpm;
-} pendant_probe_settings_t;
-
 typedef void (*keycode_callback_ptr)(const char c);
 typedef bool (*on_keypress_preview_ptr)(const char c, uint_fast16_t state);
 typedef void (*on_jogmode_changed_ptr)(jogmode_t jogmode);


### PR DESCRIPTION
For reference/review, here are the modifications that I made to the I2C keypad plugin to support macros and DRO on the JOG2K.  Notably, I am wondering if there is a better way to reference the map_coord_system and disable_lock functions as I had to copy those since they were declared as static.  That feels hacky to me so I'm sure there is a better way.

Source code for the Pico on the Jog2K is here:

https://github.com/Expatria-Technologies/I2C_Jog_Controller/blob/main/FW/i2c_responder/app_main.cpp

It is not incredibly sophisticated, but the hardware debounce on the jogger buttons helps to make the firmware simpler.