### PR TITLE
Changed cycle start and feed hold I2C key characters

### DIFF
--- a/keypad.c
+++ b/keypad.c
@@ -189,11 +189,11 @@ static void keypad_process_keypress (sys_state_t state)
                 enqueue_coolant_override(CMD_OVERRIDE_COOLANT_FLOOD_TOGGLE);
                 break;
 
-            case CMD_FEED_HOLD_LEGACY:                  // Feed hold
+            case CMD_FEED_HOLD :                  // Feed hold
                 grbl.enqueue_realtime_command(CMD_FEED_HOLD);
                 break;
 
-            case CMD_CYCLE_START_LEGACY:                // Cycle start
+            case CMD_CYCLE_START :                // Cycle start Legacy '~' is 0x7E, same as macro function
                 grbl.enqueue_realtime_command(CMD_CYCLE_START);
                 break;
 


### PR DESCRIPTION
to modern from legacy due to conflict with macro6 keycode.

As I may have to table this work for some time, I wanted to pass this upstream.