### PR TITLE
Commit fix for jogmode and reset function

### DIFF
--- a/keypad.c
+++ b/keypad.c
@@ -176,8 +176,9 @@ static void keypad_process_keypress (void *data)
     	!(keycode == CMD_STATUS_REPORT ||
 		   keycode == CMD_STATUS_REPORT_LEGACY ||
 		    keycode == CMD_RESET ||
-			 keycode == CMD_MPG_MODE_TOGGLE ||
-			  keycode == 'X' || keycode == 'H'))
+             keycode == CMD_RESET_KEYPAD ||
+			  keycode == CMD_MPG_MODE_TOGGLE ||
+			   keycode == 'X' || keycode == 'H'))
         return;
 
     if(keycode) {
@@ -222,6 +223,7 @@ static void keypad_process_keypress (void *data)
 
             case 'h':                                   // Cycle jog mode
                 jogMode = jogMode == JogMode_Step ? JogMode_Fast : (jogMode == JogMode_Fast ? JogMode_Slow : JogMode_Step);
+                jogdata.mode = jogMode;
                 if(keypad.on_jogmode_changed)
                     keypad.on_jogmode_changed(jogMode);
                 if(keypad.on_jogdata_changed)
@@ -297,6 +299,9 @@ static void keypad_process_keypress (void *data)
                 enqueue_spindle_override(keycode);
                 break;
 
+            case CMD_RESET_KEYPAD:
+                grbl.enqueue_realtime_command(CMD_RESET);
+                break;
             case CMD_RESET:
             case CMD_SAFETY_DOOR:
             case CMD_STATUS_REPORT:

--- a/keypad.c
+++ b/keypad.c
@@ -55,7 +55,6 @@ typedef struct {
 } keybuffer_t;
 
 static bool jogging = false, keyreleased = true;
-static jogmode_t jogMode = JogMode_Fast;
 static jog_settings_t jog;
 static jogdata_t jogdata = {
     .modifier[0] = 1.0f,
@@ -218,14 +217,15 @@ static void keypad_process_keypress (void *data)
             case '0':
             case '1':
             case '2':                                   // Set jog mode
-                jogMode = (jogmode_t)(keycode - '0');
+                jogdata.mode = (keycode - '0');
+                if(keypad.on_jogdata_changed)
+                    keypad.on_jogdata_changed(&jogdata);
                 break;
 
             case 'h':                                   // Cycle jog mode
-                jogMode = jogMode == JogMode_Step ? JogMode_Fast : (jogMode == JogMode_Fast ? JogMode_Slow : JogMode_Step);
-                jogdata.mode = jogMode;
+                jogdata.mode = jogdata.mode == JogMode_Step ? JogMode_Fast : (jogdata.mode == JogMode_Fast ? JogMode_Slow : JogMode_Step);
                 if(keypad.on_jogmode_changed)
-                    keypad.on_jogmode_changed(jogMode);
+                    keypad.on_jogmode_changed(jogdata.mode);
                 if(keypad.on_jogdata_changed)
                     keypad.on_jogdata_changed(&jogdata);
                 break;
@@ -387,7 +387,7 @@ static void keypad_process_keypress (void *data)
 
                 float modifier = jogdata.modifier[jogdata.modifier_index];
 
-                switch(jogMode) {
+                switch(jogdata.mode) {
 
                     case JogMode_Slow:
                         strrepl(command, '?', ftoa(jog.slow_distance, 0));
@@ -468,7 +468,7 @@ bool keypad_init (void)
         settings_register(&setting_details);
 
         if(keypad.on_jogmode_changed)
-            keypad.on_jogmode_changed(jogMode);
+            keypad.on_jogmode_changed(jogdata.mode);
     }
 
     return nvs_address != 0;
@@ -519,7 +519,7 @@ bool keypad_init (void)
             settings_register(&setting_details);
 
             if(keypad.on_jogmode_changed)
-                keypad.on_jogmode_changed(jogMode);
+                keypad.on_jogmode_changed(jogdata.mode);
         }
     }
 

--- a/keypad.c
+++ b/keypad.c
@@ -175,9 +175,8 @@ static void keypad_process_keypress (void *data)
     	!(keycode == CMD_STATUS_REPORT ||
 		   keycode == CMD_STATUS_REPORT_LEGACY ||
 		    keycode == CMD_RESET ||
-             keycode == CMD_RESET_KEYPAD ||
-			  keycode == CMD_MPG_MODE_TOGGLE ||
-			   keycode == 'X' || keycode == 'H'))
+			 keycode == CMD_MPG_MODE_TOGGLE ||
+			  keycode == 'X' || keycode == 'H'))
         return;
 
     if(keycode) {
@@ -299,9 +298,6 @@ static void keypad_process_keypress (void *data)
                 enqueue_spindle_override(keycode);
                 break;
 
-            case CMD_RESET_KEYPAD:
-                grbl.enqueue_realtime_command(CMD_RESET);
-                break;
             case CMD_RESET:
             case CMD_SAFETY_DOOR:
             case CMD_STATUS_REPORT:

--- a/keypad.c
+++ b/keypad.c
@@ -246,7 +246,7 @@ static void keypad_process_keypress (void *data)
 
          // Feed rate and spindle overrides
 
-             case 'I':                                   // Feed rate coarse override -10%
+            case 'I':                                   // Feed rate coarse override -10%
                 enqueue_feed_override(CMD_OVERRIDE_FEED_RESET);
                 break;
 
@@ -270,7 +270,7 @@ static void keypad_process_keypress (void *data)
                 enqueue_spindle_override(CMD_OVERRIDE_SPINDLE_COARSE_MINUS);
                 break;
 
-         // Pass most of the top bit set commands trough unmodified
+         // Pass most of the top bit set commands through unmodified
 
             case CMD_OVERRIDE_FEED_RESET:
             case CMD_OVERRIDE_FEED_COARSE_PLUS:
@@ -418,7 +418,7 @@ static void onReportOptions (bool newopt)
     on_report_options(newopt);
 
     if(!newopt)
-        report_plugin("Keypad", "1.39");
+        report_plugin("Keypad", "1.40");
 }
 
 #if KEYPAD_ENABLE == 1
@@ -436,13 +436,17 @@ ISR_CODE static void ISR_FUNC(i2c_enqueue_keycode)(char c)
     }
 }
 
+static void i2c_get_key (void *data)
+{
+    i2c_get_keycode(KEYPAD_I2CADDR, i2c_enqueue_keycode);
+}
+
 ISR_CODE bool ISR_FUNC(keypad_strobe_handler)(uint_fast8_t id, bool keydown)
 {
     keyreleased = !keydown;
 
     if(keydown)
-        i2c_get_keycode(KEYPAD_I2CADDR, i2c_enqueue_keycode);
-
+        task_add_immediate(i2c_get_key, NULL);
     else if(jogging) {
         jogging = false;
         grbl.enqueue_realtime_command(CMD_JOG_CANCEL);

--- a/keypad.h
+++ b/keypad.h
@@ -54,6 +54,8 @@
 #define JOG_AL   'a'
 #endif
 
+#define CMD_RESET_KEYPAD   0x7F
+
 typedef enum {
     JogMode_Fast = 0,
     JogMode_Slow,

--- a/keypad.h
+++ b/keypad.h
@@ -54,8 +54,6 @@
 #define JOG_AL   'a'
 #endif
 
-#define CMD_RESET_KEYPAD   0x7F
-
 typedef enum {
     JogMode_Fast = 0,
     JogMode_Slow,

--- a/macros.c
+++ b/macros.c
@@ -112,28 +112,28 @@ static uint8_t n_macros = N_MACROS;
 #include "keypad.h"
 
 #ifndef MACRO_KEY0
-#define MACRO_KEY0 0x18
+#define MACRO_KEY0 0xB0
 #endif
 #ifndef MACRO_KEY1
-#define MACRO_KEY1 0x19
+#define MACRO_KEY1 0xB1
 #endif
 #ifndef MACRO_KEY2
-#define MACRO_KEY2 0x1B
+#define MACRO_KEY2 0xB2
 #endif
 #ifndef MACRO_KEY3
-#define MACRO_KEY3 0x1A
+#define MACRO_KEY3 0xB3
 #endif
 #ifndef MACRO_KEY4
-#define MACRO_KEY4 0x7D
+#define MACRO_KEY4 0xB4
 #endif
 #ifndef MACRO_KEY5
-#define MACRO_KEY5 0x7C
+#define MACRO_KEY5 0xB5
 #endif
 #ifndef MACRO_KEY6
-#define MACRO_KEY6 0x7E
+#define MACRO_KEY6 0xB6
 #endif
 #ifndef MACRO_KEY7
-#define MACRO_KEY7 0x7F
+#define MACRO_KEY7 0xB7
 #endif
 
 static on_keypress_preview_ptr on_keypress_preview;


### PR DESCRIPTION
Proposed fix for two bugs identified while testing i2c display functionality on the Expatria Jog2K controller:

1. `CMD_RESET` is defined as **0x18** which conflicts with `MACRO_KEY0` if macros are enabled. As a temporary fix I have defined `CMD_RESET_KEYPAD = 0x7F`. This conflicts with `MACRO_KEY7` but is not an issue for the Jog2K since there are only 7 macro buttons. Not sure how you will feel about this fix and happy to discuss better alternatives.

2. When cycling through jog modes the change of state was not reflected in the machine status packet. Didn't seem like this warranted a full definition of the `on_jogmode_changed` function so I just added a line to update the `jogdata` struct within the keypress case.