### PR TITLE
Change to NAN flag for no rotary axis

### DIFF
--- a/display/i2c_interface.c
+++ b/display/i2c_interface.c
@@ -441,7 +441,7 @@ void display_init (void)
 
         status_packet.address = 0;
     #if N_AXIS == 3
-        status_packet.coordinate.a = NAN; // TODO: should be changed to NAN
+        status_packet.coordinate.a = NAN;
     #endif
 
         // delay final setup until startup is complete

--- a/display/i2c_interface.c
+++ b/display/i2c_interface.c
@@ -29,6 +29,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #include "i2c_interface.h"
 
@@ -68,7 +69,7 @@ static machine_status_packet_t status_packet, prev_status = {0};
 
 static void send_status_info (void *data)
 {
-    uint_fast8_t idx = min(4, N_AXIS);
+    uint_fast8_t idx = N_AXIS; //min(4, N_AXIS);
 
     system_convert_array_steps_to_mpos(status_packet.coordinate.values, sys.position);
 
@@ -97,7 +98,7 @@ static void send_status_info (void *data)
 
     status_packet.feed_rate = st_get_realtime_rate();
 
-    if(msgtype || memcmp(&prev_status, &status_packet, offsetof(machine_status_packet_t, msgtype))) {
+    if(true) {//msgtype || memcmp(&prev_status, &status_packet, offsetof(machine_status_packet_t, msgtype))) {
 
         size_t len = ((status_packet.msgtype = msgtype)) ? offsetof(machine_status_packet_t, msg) : offsetof(machine_status_packet_t, msgtype);
 
@@ -440,7 +441,7 @@ void display_init (void)
 
         status_packet.address = 0;
     #if N_AXIS == 3
-        status_packet.coordinate.a = 0xFFFFFFFF; // TODO: should be changed to NAN
+        status_packet.coordinate.a = NAN; // TODO: should be changed to NAN
     #endif
 
         // delay final setup until startup is complete

--- a/display/i2c_interface.c
+++ b/display/i2c_interface.c
@@ -69,7 +69,7 @@ static machine_status_packet_t status_packet, prev_status = {0};
 
 static void send_status_info (void *data)
 {
-    uint_fast8_t idx = N_AXIS; //min(4, N_AXIS);
+    uint_fast8_t idx = min(4, N_AXIS);
 
     system_convert_array_steps_to_mpos(status_packet.coordinate.values, sys.position);
 
@@ -98,7 +98,7 @@ static void send_status_info (void *data)
 
     status_packet.feed_rate = st_get_realtime_rate();
 
-    if(true) {//msgtype || memcmp(&prev_status, &status_packet, offsetof(machine_status_packet_t, msgtype))) {
+    if(msgtype || memcmp(&prev_status, &status_packet, offsetof(machine_status_packet_t, msgtype))) {
 
         size_t len = ((status_packet.msgtype = msgtype)) ? offsetof(machine_status_packet_t, msg) : offsetof(machine_status_packet_t, msgtype);
 


### PR DESCRIPTION
### Summary of Changes:

- update flag for no rotary axis to NAN (per request from previous PR)
- remove conditions for sending `status_packet` to ensure controller receives response from all keypress events